### PR TITLE
update boot order to include diego tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+.idea/

--- a/bootorder.txt
+++ b/bootorder.txt
@@ -24,3 +24,9 @@ dea
 doppler
 loggregator_trafficcontroller
 cloud_controller-partition
+route_emitter-partition
+brain-partition
+cc_bridge-partition
+cell-partition
+etcd_server-partition
+


### PR DESCRIPTION
added more tags to the bootorder.txt file to include the tags for vms that get created when diego is also installed
